### PR TITLE
feat: display copro name in header and home page

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -25,6 +25,23 @@ const sections = [
 const currentSection = ref(0)
 const isEnqueteOpen = ref(false)
 const isPrivacyOpen = ref(false)
+const coproName = ref('')
+
+// Fetch copro config on mount
+const fetchConfig = async () => {
+  try {
+    const response = await fetch('/api/config')
+    if (response.ok) {
+      const config = await response.json()
+      coproName.value = config.copro_name || ''
+    }
+  } catch (error) {
+    console.error('Failed to load config:', error)
+  }
+}
+
+// Provide coproName to children
+provide('coproName', coproName)
 
 const openPrivacy = () => {
   isPrivacyOpen.value = true
@@ -298,6 +315,7 @@ const handleKeydown = (e) => {
 }
 
 onMounted(() => {
+  fetchConfig()
   window.addEventListener('keydown', handleKeydown)
   window.addEventListener('hashchange', syncHashToSection)
   // Initial hash: scroll to section after DOM is ready
@@ -324,7 +342,7 @@ onUnmounted(() => {
   <div v-else class="app" :class="{ 'enquete-open': isEnqueteOpen }">
     <!-- Minimal sticky header -->
     <header class="mobile-header" :class="{ 'header-hidden': headerHidden }" v-if="!isEnqueteOpen && !isPrivacyOpen">
-      <span class="mobile-header-title">Enquête IRVE</span>
+      <span class="mobile-header-title">{{ coproName || 'Enquête IRVE' }}</span>
       <div class="mobile-header-actions">
         <button
           class="mobile-header-privacy"

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -4,6 +4,7 @@ import StatCard from '../components/StatCard.vue'
 import SvgIcon from '../components/SvgIcon.vue'
 
 const navigateToSection = inject('navigateToSection')
+const coproName = inject('coproName')
 
 const stats = ref({
   total_responses: 0,
@@ -40,6 +41,7 @@ const evCount = () => {
   <div class="page">
     <section class="hero">
       <div class="container">
+        <p v-if="coproName" class="hero-copro-name">{{ coproName }}</p>
         <h1>Bornes de recharge électrique</h1>
         <p class="hero-subtitle">
           Participez à l'enquête sur l'installation d'infrastructures de recharge
@@ -182,6 +184,19 @@ const evCount = () => {
   background: linear-gradient(135deg, var(--color-primary-light) 0%, var(--color-bg) 100%);
   padding: 4rem 0;
   text-align: center;
+}
+
+.hero-copro-name {
+  display: inline-block;
+  background: var(--color-primary);
+  color: white;
+  padding: 0.375rem 1rem;
+  border-radius: 999px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .hero h1 {


### PR DESCRIPTION
## Summary

Display the copropriété name in the UI for better multi-tenant identification.

## Changes

- **Header**: Shows copro name instead of generic "Enquête IRVE"
- **Home page**: Shows copro name as a badge above the main title

## Screenshots

The copro name appears:
1. In the sticky header (e.g., "Le Clos des Églantines")
2. As a green pill/badge in the hero section

## Test plan

- [ ] Visit https://demo.evpoll.app - should show "Démo EV Poll"
- [ ] Visit https://cedeg.evpoll.app - should show "Le Clos des Églantines"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)