### PR TITLE
docs: clarify PM2 ecosystem config vs dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,16 @@ node_modules/
 # Build output
 dist/
 build/
+backend/public/
 
 # Environment files
 .env
 .env.local
 .env.*.local
+
+# PM2 ecosystem config (contains secrets)
+ecosystem.config.cjs
+ecosystem.config.js
 
 # Database (SQLite)
 *.db

--- a/docs/MULTI_TENANT.md
+++ b/docs/MULTI_TENANT.md
@@ -80,6 +80,19 @@ mkdir -p data
 
 ### Créer le fichier de configuration PM2
 
+> **Pourquoi `ecosystem.config.cjs` et pas `.env` ?**
+>
+> Node.js ne charge **pas** automatiquement les fichiers `.env`. Il faudrait ajouter
+> le package `dotenv` comme dépendance. On utilise plutôt `ecosystem.config.cjs` car :
+>
+> - ✅ Pas de dépendance npm supplémentaire
+> - ✅ PM2 gère nativement les variables d'environnement
+> - ✅ Configuration explicite par instance
+> - ✅ Fichier `.cjs` (CommonJS) requis car PM2 ne supporte pas ESM pour les configs
+>
+> ⚠️ **Sécurité** : Ne commitez jamais ce fichier dans git (contient le mot de passe admin).
+> Ajoutez `ecosystem.config.cjs` à votre `.gitignore`.
+
 Créez `/var/www/evpoll-nouveau-client/backend/ecosystem.config.cjs` :
 
 ```javascript


### PR DESCRIPTION
## Summary

Clarify why we use `ecosystem.config.cjs` instead of `.env` files for configuration.

## Changes

- **docs/MULTI_TENANT.md**: Added explanation box about:
  - Node.js doesn't auto-load `.env` files
  - Why PM2 ecosystem config is preferred
  - Security warning about not committing secrets

- **.gitignore**: Added:
  - `ecosystem.config.cjs` and `ecosystem.config.js`
  - `backend/public/` (build artifact)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)